### PR TITLE
feat: support postcss config files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "@remix-run/node": "^1.1.1",
-    "@types/tailwindcss": "^2.2.4"
+    "@types/tailwindcss": "^2.2.4",
+    "postcss-load-config": "^3.1.4"
   },
   "peerDependencies": {
     "postcss": ">=8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ importers:
       execa: ^6.0.0
       jest: ^27.4.5
       postcss: ^8.4.5
+      postcss-load-config: ^3.1.4
       prettier: ^2.5.1
       release-it: ^14.11.8
       tailwindcss: ^3.0.7
@@ -34,6 +35,7 @@ importers:
     dependencies:
       '@remix-run/node': 1.1.1
       '@types/tailwindcss': 2.2.4
+      postcss-load-config: 3.1.4_postcss@8.4.5
     devDependencies:
       '@itsmapleleaf/configs': 1.1.2
       '@jest/types': 27.4.2
@@ -58,7 +60,7 @@ importers:
       prettier: 2.5.1
       release-it: 14.11.8
       tailwindcss: 3.0.7_postcss@8.4.5
-      tsup: 5.11.6_typescript@4.5.4
+      tsup: 5.11.6_postcss@8.4.5+typescript@4.5.4
       typescript: 4.5.4
 
   test/fixtures/remix-app:
@@ -5796,10 +5798,9 @@ packages:
       type-check: 0.4.0
     dev: true
 
-  /lilconfig/2.0.4:
-    resolution: {integrity: sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==}
+  /lilconfig/2.0.5:
+    resolution: {integrity: sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==}
     engines: {node: '>=10'}
-    dev: true
 
   /lines-and-columns/1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -7134,19 +7135,21 @@ packages:
       postcss: 8.4.5
     dev: true
 
-  /postcss-load-config/3.1.0:
-    resolution: {integrity: sha512-ipM8Ds01ZUophjDTQYSVP70slFSYg3T0/zyfII5vzhN6V57YSxMgG5syXuwi5VtS8wSf3iL30v0uBdoIVx4Q0g==}
+  /postcss-load-config/3.1.4_postcss@8.4.5:
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
+      postcss: '>=8.0.9'
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
+      postcss:
+        optional: true
       ts-node:
         optional: true
     dependencies:
-      import-cwd: 3.0.0
-      lilconfig: 2.0.4
+      lilconfig: 2.0.5
+      postcss: 8.4.5
       yaml: 1.10.2
-    dev: true
 
   /postcss-nested/5.0.6_postcss@8.4.5:
     resolution: {integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==}
@@ -8274,7 +8277,7 @@ packages:
       object-hash: 2.2.0
       postcss: 8.4.5
       postcss-js: 3.0.3
-      postcss-load-config: 3.1.0
+      postcss-load-config: 3.1.4_postcss@8.4.5
       postcss-nested: 5.0.6_postcss@8.4.5
       postcss-selector-parser: 6.0.7
       postcss-value-parser: 4.2.0
@@ -8467,7 +8470,7 @@ packages:
     resolution: {integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==}
     dev: true
 
-  /tsup/5.11.6_typescript@4.5.4:
+  /tsup/5.11.6_postcss@8.4.5+typescript@4.5.4:
     resolution: {integrity: sha512-mKhLdQ1N2KMV31dsX4MLO5l4FOORf2+FvyAOott3ZgiSnKisZiOoCXwxPc97iPqIk5aouyQBTaZcjXKJV+C4pg==}
     hasBin: true
     peerDependencies:
@@ -8484,7 +8487,7 @@ packages:
       execa: 5.1.1
       globby: 11.0.4
       joycon: 3.1.1
-      postcss-load-config: 3.1.0
+      postcss-load-config: 3.1.4_postcss@8.4.5
       resolve-from: 5.0.0
       rollup: 2.61.1
       source-map: 0.7.3
@@ -8492,6 +8495,7 @@ packages:
       tree-kill: 1.2.2
       typescript: 4.5.4
     transitivePeerDependencies:
+      - postcss
       - supports-color
       - ts-node
     dev: true
@@ -9073,7 +9077,6 @@ packages:
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
-    dev: true
 
   /yargs-parser/18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}


### PR DESCRIPTION
closes https://github.com/itsMapleLeaf/remix-tailwind/issues/5

I used an official package called [`postcss-load-config`](https://github.com/postcss/postcss-load-config) that looks for PostCSS config files. 
All previous tests pass. Let me know what you think about the changes.